### PR TITLE
ES-846833-Add DocIO & Presentation controls in Xamarin iOS platform UG-hotfix

### DIFF
--- a/xamarin-ios-toc.html
+++ b/xamarin-ios-toc.html
@@ -537,54 +537,7 @@
                 <a href="/file-formats/Presentation/Overview">Overview</a>
             </li>
             <li>
-                <a href="/file-formats/Presentation/Assemblies-Required">Assemblies Required</a>
-            </li>
-            <li>
                 <a href="/file-formats/Presentation/Getting-Started">Getting Started</a>
-            </li>
-            <li>
-                <a href="/file-formats/Presentation/Document-Object-Model">Document Object Model</a>
-            </li>
-            <li>
-                <a href="/file-formats/Presentation/Loading-and-Saving-the-Presentation">Loading and saving Presentation</a>
-            </li>
-            <li>
-                <a href="/file-formats/Presentation/Xamarin">Xamarin</a>
-            </li>
-            <li>
-                <a href="/file-formats/Presentation/Working-with-PowerPoint-presentation">Working with Presentation</a>
-            </li>
-            <li>
-                <a href="/file-formats/Presentation/Working-with-Slide">Working with Slides</a>
-            </li>
-            <li>
-                <a href="/file-formats/Presentation/Working-with-paragraphs">Working with Paragraphs</a>
-            </li>
-            <li>
-                <a href="/file-formats/Presentation/Working-with-list">Working with Lists</a>
-            </li>
-            <li>
-                <a href="/file-formats/Presentation/Working-with-shapes">Working with Shapes</a>
-            </li>
-            <li>
-                <a href="/file-formats/Presentation/Working-with-images">Working with Images</a>
-            </li>
-            <li>
-                <a href="/file-formats/Presentation/Working-with-Tables">Working with Tables</a>
-            </li>
-            <li>
-                <a href="/file-formats/Presentation/Working-with-Charts">Working with Charts</a>
-            </li>
-            <li>
-                <a href="/file-formats/Presentation/Working-with-NotesSlide">Working with Notes</a>
-            </li>
-            <li>
-                <a href="/file-formats/Presentation/SmartArt">Working with SmartArts</a>
-            </li>
-
-            <li><a href="/file-formats/Presentation/Supported-and-Unsupported-Features">Supported and Unsupported Features</a></li>
-            <li>
-                <a href="/file-formats/Presentation/FAQ">FAQ</a>
             </li>
         </ul>
     </li>
@@ -768,7 +721,13 @@
             <li><a href="/xamarin-ios/sftreeview/right-to-left">Right to left(RTL)</a></li>
         </ul>
     </li>
-    <li>DocIO</li>
+    <li>
+	    DocIO
+		<ul>
+            <li><a href="/file-formats/DocIO/Overview">Overview</a></li>
+            <li><a href="/file-formats/DocIO/Getting-started">Getting Started</a></li>
+		</ul>
+	</li>
 	<li>
         XlsIO
         <ul>


### PR DESCRIPTION
Hi all,

- With this PR, we have modified the DocIO & Presentation controls direct links in Xamarin iOS platform UG.
- Removed pages other than Overview and Getting Started.

Regards,
Dharanitharan A